### PR TITLE
Refactor "forgot password" feature

### DIFF
--- a/app/api/v1/endpoints/user.py
+++ b/app/api/v1/endpoints/user.py
@@ -8,7 +8,6 @@ from app.schemas.user import UserCreate, UserRead, ForgotPassword, ResetPassword
 from app.models.user import User
 from app.services.user_service import user_service
 from app.core.context import request_id_var
-from app.core.rabbitmq import rabbitmq_manager
 
 router = APIRouter()
 
@@ -38,7 +37,7 @@ async def forgot_password(
     db: Annotated[AsyncSession, Depends(get_db)], 
     user_in: ForgotPassword
 ):
-    await user_service.start_password_reset(db=db,email=user_in.email)
+    await user_service.request_password_reset(email=user_in.email)
     return {"message": "If an account with this email exists, a password reset link will be sent."}
 
 @router.post("/reset-password")

--- a/app/core/rabbitmq.py
+++ b/app/core/rabbitmq.py
@@ -42,7 +42,7 @@ class RabbitMQManager:
         try:
             channel = await self.get_channel()
             queue = await channel.declare_queue(queue_name, durable=True)
-            await channel.default.exchange_publish(
+            await channel.default_exchange.publish(
                 aio_pika.Message(
                     body=json.dumps(message_body).encode(),
                     delivery_mode=aio_pika.DeliveryMode.PERSISTENT

--- a/app/models/session.py
+++ b/app/models/session.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from app.models.base import TimestampModel
 
 if TYPE_CHECKING:
-    from app.model.user import User
+    from app.models.user import User
 
 class Session(TimestampModel, table=True):
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)

--- a/app/repositories/password_reset_token_repo.py
+++ b/app/repositories/password_reset_token_repo.py
@@ -9,11 +9,10 @@ class PasswordResetTokenRepo(BaseRepo):
         super().__init__(PasswordResetToken)
 
     async def get_by_token_hash(self, *, db: AsyncSession, token_hash: str):
-        return await self.get_by_field(db=db, field_name="token_hash", value=some_hash)
+        return await self.get_by_field(db=db, field_name="token_hash", value=token_hash)
 
     async def delete_all_for_user(self, *, db: AsyncSession, user_id=int):
         statement = delete(self.model).where(self.model.user_id==user_id)
         await db.exec(statement)
-        await db.commit()
 
 password_reset_token_repo = PasswordResetTokenRepo()


### PR DESCRIPTION
  Key changes include:
    - The `/forgot-password` endpoint now only publishes a message to a queue and returns immediately, improving user experience and decoupling the API from the business logic.
    - The background worker is now responsible for the entire transactional process: creating the database reset token and sending the email.
    - This "Queue First" approach prevents inconsistent states where a DB token could be created without a corresponding email being sent if the message broker were to fail.

  Fixes:
    - Corrects a bug in the RabbitMQ publisher where an incorrect attribute (`channel.default`) was used instead of `channel.default_exchange`.
    - Resolves a `KeyError: 'Session'` in the worker by explicitly importing all SQLModel classes at startup, ensuring SQLAlchemy's model registry is fully populated.
    - Fixes a typo in the `Session` model's import path.